### PR TITLE
Adds logic testing with local builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
             circleci orb validate packed.yml
             circleci orb publish packed.yml sandbox/artifactory@dev:${CIRCLE_BRANCH} --token ${CIRCLE_API_TOKEN}
       - install-bats
+      - setup_remote_docker
       - run:
           name: Import Tests using BATS
           command: |

--- a/tests/bats_helper.bash
+++ b/tests/bats_helper.bash
@@ -60,7 +60,7 @@ function assert_matches_file {
 	return $?
 }
 
-function only_run_integration {
+function requires_local_build {
 	run docker version
 	if [ $status -ne 0 ]; then
 		skip "Docker must be configured for this test to run"

--- a/tests/bats_helper.bash
+++ b/tests/bats_helper.bash
@@ -65,4 +65,11 @@ function requires_local_build {
 	if [ $status -ne 0 ]; then
 		skip "Docker must be configured for this test to run"
 	fi
+
+	# hack to work for remote docker where config is not local
+	docker run --name lifter-${BATS_TEST_NUMBER} -v $(pwd):$(pwd) alpine:3.4 sleep 10 #starts a docker container with access to host FS, should live long enough for cp commay to suceeed
+	docker cp $1 lifter-${BATS_TEST_NUMBER}:$(pwd)  # copies file from local job to remote docker, which is mounted host FS
+	docker stop lifter-${BATS_TEST_NUMBER} && docker rm lifter-${BATS_TEST_NUMBER}
+	# now CLI should see that local file!
 }
+

--- a/tests/bats_helper.bash
+++ b/tests/bats_helper.bash
@@ -67,9 +67,9 @@ function requires_local_build {
 	fi
 
 	# hack to work for remote docker where config is not local
-	docker run --name lifter-${BATS_TEST_NUMBER} -v $(pwd):$(pwd) alpine:3.4 sleep 10 #starts a docker container with access to host FS, should live long enough for cp commay to suceeed
+	docker run --name lifter-${BATS_TEST_NUMBER} -v $(pwd):$(pwd) alpine:3.4 /bin/true #starts a docker container that immediately exits
 	docker cp $1 lifter-${BATS_TEST_NUMBER}:$(pwd)  # copies file from local job to remote docker, which is mounted host FS
-	docker stop lifter-${BATS_TEST_NUMBER} && docker rm lifter-${BATS_TEST_NUMBER}
+	docker rm lifter-${BATS_TEST_NUMBER} || true
 	# now CLI should see that local file!
 }
 

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -127,10 +127,9 @@ function setup {
   # when
   # IMPORTANT ** circleci only mounts local directory, so our generated config file must live here.
   circleci config process $CONFIG_FILE > local.yml
-
-  requires_local_build local.yml
-  
+  requires_local_build local.yml # copies our local file to remote docker.
   run circleci build -c local.yml
+  rm local.yml
 
   # then
   assert_contains_text 'Checking for existence of CLI'

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -120,29 +120,30 @@ function setup {
 
 
 @test "Command: install logic skips if aleady installed" {
-  requires_local_build
-  
 
   # given
   print_config tests/inputs/command-install.yml > $CONFIG_FILE
 
   # when
   # IMPORTANT ** circleci only mounts local directory, so our generated config file must live here.
-  circleci config process $CONFIG_FILE > temp-config.yml
-  run circleci build -c temp-config.yml
-  rm temp-config.yml
+  circleci config process $CONFIG_FILE > $CONFIG_FILE-processed
+
+  requires_local_build $CONFIG_FILE-processed
+  
+  run circleci build -c $CONFIG_FILE-processed
 
   # then
   assert_contains_text 'Checking for existence of CLI'
   assert_contains_text 'Not found, installing latest'
 }
 
+
+
+
+
 @test "Command: configure command prints nice warnings if envars missing " {
   
-
   skip
-
-
 
   # given
   print_config tests/inputs/command-configure.yml > $CONFIG_FILE

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -126,11 +126,11 @@ function setup {
 
   # when
   # IMPORTANT ** circleci only mounts local directory, so our generated config file must live here.
-  circleci config process $CONFIG_FILE > $CONFIG_FILE-processed
+  circleci config process $CONFIG_FILE > local.yml
 
-  requires_local_build $CONFIG_FILE-processed
+  requires_local_build local.yml
   
-  run circleci build -c $CONFIG_FILE-processed
+  run circleci build -c local.yml
 
   # then
   assert_contains_text 'Checking for existence of CLI'

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -120,7 +120,7 @@ function setup {
 
 
 @test "Command: install logic skips if aleady installed" {
-  only_run_integration
+  requires_local_build
   
 
   # given


### PR DESCRIPTION
I have external project that excercises configs, but basic logic can be checked as part of our workflow using local builds and remote docker.