### PR TITLE
preping namespace for release as circleci/artifactory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,12 +52,12 @@ jobs:
           command: |
             circleci config pack src/ > packed.yml
             circleci orb validate packed.yml --token ${CIRCLE_API_TOKEN}
-            circleci orb publish packed.yml sandbox/artifactory@dev:${CIRCLE_BRANCH} --token ${CIRCLE_API_TOKEN}
+            circleci orb publish packed.yml circleci/artifactory@dev:${CIRCLE_BRANCH} --token ${CIRCLE_API_TOKEN}
       - install-bats
       - run:
           name: Import Tests using BATS
           command: |
-            export BATS_IMPORT_DEV_ORB="sandbox/artifactory@dev:${CIRCLE_BRANCH}"
+            export BATS_IMPORT_DEV_ORB="circleci/artifactory@dev:${CIRCLE_BRANCH}"
             bats tests
 
   publish:
@@ -67,16 +67,14 @@ jobs:
       - checkout
       - install-circleci
       - run:
-          name: Publish prod
+          name: Promote to prod
           command: |
-            circleci config pack src/ > packed.yml
-            circleci orb validate packed.yml --token ${CIRCLE_API_TOKEN}
-            circleci orb publish packed.yml sandbox/artifactory@1.0.${CIRCLE_BUILD_NUM} --token ${CIRCLE_API_TOKEN}
+            circleci orb publish promote circleci/artifactory@dev:${CIRCLE_BRANCH} patch --token ${CIRCLE_API_TOKEN}
       - install-bats
       - run:
           name: Import Tests using BATS
           command: |
-            export BATS_IMPORT_DEV_ORB="sandbox/artifactory@1.0.${CIRCLE_BUILD_NUM}"
+            export BATS_IMPORT_DEV_ORB="circleci/artifactory@volatile"
             bats tests
 
   smoke-test:


### PR DESCRIPTION
Merging this into master will promote the orb to `0.0.1` in the new namespace.  We can then manually promote that to `1.0.0`