### PR TITLE
add `promote build` command and job

### DIFF
--- a/src/commands/promote.yml
+++ b/src/commands/promote.yml
@@ -1,0 +1,47 @@
+description: >
+  Promote assets on Artifactory via `jfrog rt build-promote`. For details, see
+  https://jfrog.com/confluence/display/CLI/CLI+for+JFrog+Artifactory#CLIforJFrogArtifactory-UploadingFiles
+
+parameters:
+  comment:
+    type: string
+    default: ""
+    description: >
+      Optional comment for the promoted build.
+
+  status:
+    type: string
+    default: ""
+    description: >
+      Optional status for the promoted build.
+
+  target:
+    type: string
+    default: ""
+    description: >
+      Target path in Artifactory for uploads, in the following format:
+      [repository_name]/[repository_path]
+
+  build-name:
+    type: string
+    default: ${CIRCLE_PROJECT_REPONAME}
+    description: >
+      Artifactory build name, defaults to the value of
+      $CIRCLE_PROJECT_REPONAME
+
+  build-number:
+    type: string
+    default: ${CIRCLE_BUILD_NUM}
+    description: >
+      Artifactory build number, defaults to the value of $CIRCLE_BUILD_NUM
+
+steps:
+  - run:
+      name: Promote assets with JFrog CLI
+      command: |
+        jfrog rt build-promote \
+          <<#parameters.comment>>--comment "<<parameters.comment>>"<</parameters.comment>> \
+          <<#parameters.status>>--status "<<parameters.status>>"<</parameters.status>> \
+          <<parametes.build-name>> \
+          <<parameters.build-number>> \
+          <<parameters.target>>

--- a/src/commands/promote.yml
+++ b/src/commands/promote.yml
@@ -1,6 +1,6 @@
 description: >
   Promote assets on Artifactory via `jfrog rt build-promote`. For details, see
-  https://jfrog.com/confluence/display/CLI/CLI+for+JFrog+Artifactory#CLIforJFrogArtifactory-UploadingFiles
+  https://www.jfrog.com/confluence/display/CLI/CLI+for+JFrog+Artifactory#CLIforJFrogArtifactory-BuildIntegration-PromotingaBuild
 
 parameters:
   comment:
@@ -19,7 +19,7 @@ parameters:
     type: string
     default: ""
     description: >
-      Target path in Artifactory for uploads, in the following format:
+      Target path in Artifactory for promotions, in the following format:
       [repository_name]/[repository_path]
 
   build-name:

--- a/src/examples/promote-command.yml
+++ b/src/examples/promote-command.yml
@@ -1,0 +1,23 @@
+description: >
+  Use the `docker-publish` job to build and tag a Docker image, then
+  push it to a JFrog Docker registry and promote it.
+
+usage:
+  version: 2.1
+
+  orbs:
+    artifactory: circleci/artifactory@1.0.0
+
+  workflows:
+    simple-docker-example:
+      jobs:
+        - artifactory/docker-publish:
+            name: Docker Publish Simple
+            docker-registry: orbdemos-docker-local.jfrog.io
+            repository: docker-build
+            docker-tag: orbdemos-docker-local.jfrog.io/hello-world:1.0-${CIRCLE_BUILD_NUM}
+        - artifactory/promote:
+            name: Promote a build
+            build-name: "hello-world"
+            build-number: "1.0-${CIRCLE_BUILD_NUM}"
+            taget: docker-local

--- a/src/examples/promote-command.yml
+++ b/src/examples/promote-command.yml
@@ -11,6 +11,8 @@ usage:
   workflows:
     simple-docker-example:
       jobs:
+        - artifactory/install
+        - artifactory/configure
         - artifactory/docker-publish:
             name: Docker Publish Simple
             docker-registry: orbdemos-docker-local.jfrog.io

--- a/src/examples/promote-job.yml
+++ b/src/examples/promote-job.yml
@@ -1,0 +1,18 @@
+description: >
+  Use the `upload` job to upload artifacts to JFrog's Artifactory
+
+usage:
+  version: 2.1
+
+  orbs:
+    artifactory: circleci/artifactory@1.0.0
+
+  workflows:
+    publish:
+      jobs:
+        - artifactory/upload:
+            name: Publish Maven Jar
+            source: test/artifact.jar
+            target: repo/path
+            build-steps:
+              - run: mvn install -B

--- a/src/examples/promote-job.yml
+++ b/src/examples/promote-job.yml
@@ -1,5 +1,5 @@
 description: >
-  Use the `upload` job to upload artifacts to JFrog's Artifactory
+  Use the `promote` job to promote artifacts in JFrog's Artifactory
 
 usage:
   version: 2.1
@@ -10,9 +10,13 @@ usage:
   workflows:
     publish:
       jobs:
-        - artifactory/upload:
-            name: Publish Maven Jar
-            source: test/artifact.jar
-            target: repo/path
-            build-steps:
-              - run: mvn install -B
+        - artifactory/docker-publish:
+            name: Docker Publish Simple
+            docker-registry: orbdemos-docker-local.jfrog.io
+            repository: docker-build
+            docker-tag: orbdemos-docker-local.jfrog.io/hello-world:1.0-${CIRCLE_BUILD_NUM}
+        - artifactory/promote:
+            name: Promote a build
+            build-name: "hello-world"
+            build-number: "1.0-${CIRCLE_BUILD_NUM}"
+            taget: docker-local

--- a/src/jobs/promote.yml
+++ b/src/jobs/promote.yml
@@ -17,7 +17,7 @@ parameters:
       type: string
       default: ""
       description: >
-        Target path in Artifactory for uploads, in the following format:
+        Target path in Artifactory for promotions, in the following format:
         [repository_name]/[repository_path]
 
     build-name:

--- a/src/jobs/promote.yml
+++ b/src/jobs/promote.yml
@@ -1,0 +1,48 @@
+description: Promote artifacts in Artifactory
+
+parameters:
+    comment:
+      type: string
+      default: ""
+      description: >
+        Optional comment for the promoted build.
+
+    status:
+      type: string
+      default: ""
+      description: >
+        Optional status for the promoted build.
+
+    target:
+      type: string
+      default: ""
+      description: >
+        Target path in Artifactory for uploads, in the following format:
+        [repository_name]/[repository_path]
+
+    build-name:
+      type: string
+      default: ${CIRCLE_PROJECT_REPONAME}
+      description: >
+        Artifactory build name, defaults to the value of
+        $CIRCLE_PROJECT_REPONAME
+
+    build-number:
+      type: string
+      default: ${CIRCLE_BUILD_NUM}
+      description: >
+        Artifactory build number, defaults to the value of $CIRCLE_BUILD_NUM
+
+steps:
+  - checkout
+
+  - install
+
+  - configure
+
+  - promote:
+      comment: <<parameters.comment>>
+      status: <<parameters.status>>
+      target: <<parameters.target>>
+      build-name: <<parameters.build-name>>
+      build-number: <<parameters.build-number>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

Closes #7

### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

adds `promote` command to `artifactory-orb`.  this adds the command to promote
a package in artifactory, as well as the job to do the task as well - including all the auth
